### PR TITLE
update markdown hashes to work with Gatsby nav syntax

### DIFF
--- a/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
+++ b/samples/05_content_publishers/create_and_load_knowledge_graph_backups.ipynb
@@ -49,9 +49,11 @@
    "id": "6c9288de",
    "metadata": {},
    "source": [
-    "## Never lose your graphs again with backups!\n",
+    "_**Never lose your graphs again with backups!**_\n",
+    "\n",
     "Create a backup of an ArcGIS Knowledge graph you have created to store your data model and data. The backup will be in the format of json files that can read to recreate your graph or be shared for others to be able to create the same graph on a different server.\n",
-    "## Load a new graph easily from your backup files!\n",
+    "\n",
+    "_**Load a new graph easily from your backup files!**_\n",
     "Use the backup files with the load backup files portion of this notebook to create a graph with the same data model and data."
    ]
   },
@@ -60,7 +62,7 @@
    "id": "b373d48b",
    "metadata": {},
    "source": [
-    "# Setup"
+    "## Setup"
    ]
   },
   {
@@ -68,7 +70,7 @@
    "id": "d20f5e6c",
    "metadata": {},
    "source": [
-    "## Import necessary libraries\n",
+    "### Import necessary libraries\n",
     "Start by importing the libraries we need for connecting to portal, accessing knowledge graph, and manipulating data as needed"
    ]
   },
@@ -92,7 +94,7 @@
    "id": "b14f1c6e",
    "metadata": {},
    "source": [
-    "## Define folder and file names\n",
+    "### Define folder and file names\n",
     "Define all names for files so we can stay consistent for backing up and loading files"
    ]
   },
@@ -119,7 +121,7 @@
    "id": "8efc688e",
    "metadata": {},
    "source": [
-    "# Create backup files"
+    "## Create backup files"
    ]
   },
   {
@@ -127,7 +129,7 @@
    "id": "b58d0f34",
    "metadata": {},
    "source": [
-    "## Connect to portal and knowledge graph\n",
+    "### Connect to portal and knowledge graph\n",
     "Connect to the portal and knowledge graph on that portal, also ensure knowledge graph service exists (url is correct)"
    ]
   },
@@ -155,7 +157,7 @@
    "id": "ced3a37e",
    "metadata": {},
    "source": [
-    "## Write data model entity types to backup json file\n",
+    "### Write data model entity types to backup json file\n",
     "Iterate through the data model of the knowledge graph to write all entity type objects to a backup json file"
    ]
   },
@@ -195,7 +197,7 @@
    "id": "dff06f42",
    "metadata": {},
    "source": [
-    "## Write data model relationship types to backup json file\n",
+    "### Write data model relationship types to backup json file\n",
     "Iterate through the data model of the knowledge graph to write all relationship type objects to a backup json file"
    ]
   },
@@ -235,7 +237,7 @@
    "id": "dd6f9f53",
    "metadata": {},
    "source": [
-    "## Write entities to backup json file\n",
+    "### Write entities to backup json file\n",
     "Get all entities from the knowledge graph using a streaming query, clean them up for better writing when loading, and save the resulting entities to a json backup file"
    ]
   },
@@ -292,7 +294,7 @@
    "id": "53d50a65",
    "metadata": {},
    "source": [
-    "## Write relationships to backup json file\n",
+    "### Write relationships to backup json file\n",
     "Get all relationships from the knowledge graph using a streaming query, clean them up for better writing when loading, and save the resulting relationships to a json backup file"
    ]
   },
@@ -414,7 +416,7 @@
    "id": "c21c8066",
    "metadata": {},
    "source": [
-    "# Load backup files"
+    "## Load backup files"
    ]
   },
   {
@@ -422,7 +424,7 @@
    "id": "db4a59d8",
    "metadata": {},
    "source": [
-    "## Connect to portal and create knowledge graph\n",
+    "### Connect to portal and create knowledge graph\n",
     "Connect to the portal and create a new knowledge graph service to load data model and data into"
    ]
   },
@@ -453,7 +455,7 @@
    "id": "70b11b8a",
    "metadata": {},
    "source": [
-    "## Populate data model from saved json files\n",
+    "### Populate data model from saved json files\n",
     "Populate entity and relationship types from saved json files. This is using the variables defined in the 'Setup' section above."
    ]
   },
@@ -479,7 +481,7 @@
    "id": "85163b0a",
    "metadata": {},
    "source": [
-    "## Get original documents names to correctly load data\n",
+    "### Get original documents names to correctly load data\n",
     "This section will get the names of the document entity and relationship types from the original graph data, using the above commands the document types get their default names of 'Document' and 'HasDocument'. Just in case they have been named differently in the original knowledge graph, this steps allows us to match them up in later loading steps."
    ]
   },
@@ -521,7 +523,7 @@
    "id": "fd1eecc7",
    "metadata": {},
    "source": [
-    "## Add additional document entity and relationship type properties\n",
+    "### Add additional document entity and relationship type properties\n",
     "In the case additional properties exist in the original graph on document entity or relationship types, since the type was created at the time of knowledge graph creation we need to additional properties using graph_property_adds."
    ]
   },
@@ -569,7 +571,7 @@
    "id": "31027810",
    "metadata": {},
    "source": [
-    "## Get list of date properties from the data model json files\n",
+    "### Get list of date properties from the data model json files\n",
     "From the data model type json files, find and make a list of date files so we can correctly create datetime objects when loading the data into the knowledge graph."
    ]
   },
@@ -607,7 +609,7 @@
    "id": "33eca61c",
    "metadata": {},
    "source": [
-    "## Add all entities to the knowledge graph\n",
+    "### Add all entities to the knowledge graph\n",
     "Add all entities from json file to the knowledge graph, formatting UUIDs, dates, and documents before loading the values. This loads the data in batches of 20,000 entities."
    ]
   },
@@ -665,7 +667,7 @@
    "id": "034ed628",
    "metadata": {},
    "source": [
-    "## Add all relationships to the knowledge graph\n",
+    "### Add all relationships to the knowledge graph\n",
     "Add all relationships from json file to the knowledge graph, formatting UUIDs, dates, and documents before loading the values. This loads the data in batches of 20,000 relationships."
    ]
   },
@@ -729,7 +731,7 @@
    "id": "7d67f4ed",
    "metadata": {},
    "source": [
-    "## Add search indexes to all text properties\n",
+    "### Add search indexes to all text properties\n",
     "Adding search indexes to all text properties will allow for the values in those properties to be searched for when using search in any client."
    ]
   },
@@ -835,7 +837,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.17"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi @mbana641

Thanks for the sample notebook - it all looks great.
* just to confirm - you do not intend for there to be any output cells...correct?
* I am submitting this PR to update the number of hashmarks in the notebook.  The Gatsby application that builds the Developer Website reads the number of hashmarks to build the right-hand navigation on the sample pages. There are some _rules_ to how the application handles things:
  * Single hashmark - `#` - Used for individual cell as the Title of the web page
  * Double hashmark - `##` - Main heading in the navigation
  * Triple hashmark - `###` - Subheadings for any double hashmark markdown cells above it

* I edited your notebook to update the markdown headings to reorganize the nav and make it so there was only one title cell to hopefully make the appearance cleaner.  I included a couple screenshot of how the sample appears in a locally built instance of the Developer Website. If you're ok with this, please merge this PR into your branch. You may have to push these changes back into the PR, too.

Let me know if you have any questions or concerns over the changes in this PR.

|**Before**|**After**|
|---|---|
![image](https://github.com/mbana641/arcgis-python-api/assets/1399179/897ab5aa-0d8a-4f72-869f-e07e9bab53dd)|![image](https://github.com/mbana641/arcgis-python-api/assets/1399179/879b94de-4f06-4625-b3d9-b62a77b107c0)

|**Before**|**After**|
|---|---|
![image](https://github.com/mbana641/arcgis-python-api/assets/1399179/2d24700a-5e37-4d8f-9b79-6424653d8bc8)|![image](https://github.com/mbana641/arcgis-python-api/assets/1399179/a5e77708-aacd-448b-92cf-528b20f5961f)|

